### PR TITLE
Using Access is much slower than Map.get

### DIFF
--- a/lib/board/map2d.ex
+++ b/lib/board/map2d.ex
@@ -8,7 +8,7 @@ defmodule Board.Map2D do
     |> Map.new()
   end
 
-  def get(board, x, y), do: board[x][y]
+  def get(board, x, y), do: board |> Map.get(x) |> Map.get(y)
 
   def set(board, x, y, value) do
     put_in(board[x][y], value)

--- a/lib/board/map_tuple.ex
+++ b/lib/board/map_tuple.ex
@@ -7,7 +7,7 @@ defmodule Board.MapTuple do
     %{}
   end
 
-  def get(board, x, y), do: board[{x, y}]
+  def get(board, x, y), do: Map.get(board, {x, y})
 
   def set(board, x, y, value) do
     Map.put(board, {x, y}, value)

--- a/lib/board/map_tuple_full.ex
+++ b/lib/board/map_tuple_full.ex
@@ -11,7 +11,7 @@ defmodule Board.MapTupleFull do
     |> Map.new()
   end
 
-  def get(board, x, y), do: board[{x, y}]
+  def get(board, x, y), do: Map.get(board, {x, y})
 
   def set(board, x, y, value) do
     Map.put(board, {x, y}, value)

--- a/lib/board/map_tuple_half_full.ex
+++ b/lib/board/map_tuple_half_full.ex
@@ -11,7 +11,7 @@ defmodule Board.MapTupleHalfFull do
     |> Map.new()
   end
 
-  def get(board, x, y), do: board[{x, y}]
+  def get(board, x, y), do: Map.get(board, {x, y})
 
   def set(board, x, y, value) do
     Map.put(board, {x, y}, value)


### PR DESCRIPTION
As an example, this speeds up MapTupleFull `get(8, 8)` from average ~9.81 μs to average ~200ns.

Doing `map[x]` uses `Access` which is much slower than eg `Map.get(map, x)`.